### PR TITLE
Web base docs

### DIFF
--- a/docs/40_modules/93_base/01_Getting_Started/1-introduction.md
+++ b/docs/40_modules/93_base/01_Getting_Started/1-introduction.md
@@ -12,6 +12,19 @@ The Web-base template is a frontend foundation built using Svelte, designed to a
 - Keycloak Authentication: Web-base integrates with Keycloak, a popular open-source identity and access management solution, to provide secure authentication and authorization as well as multitenancy.
 - Basic UI Components: The template includes a set of basic UI components, such as navigation, buttons, and forms, to help you get started with building your frontend module.
 
+## Technologies used
+
+In order to build off the web-base, there are a few prerequisite technologies that you'll have to pick up. We have chosen `Svelte` as our primary component-based UI framework and `Sveltekit` as the web application framework (routing) for Svelte.
+
+We are also using `TypeScript`, on top of `JavaScript`, for better maintainability and improved developer productivity. `TypeScript` introduces static typing to `JavaScript`, which allows us to catch type-related errors at compile time rather than runtime.
+
+For styling, we are using `TailwindCSS` to style our components.
+
+For more information on these technologies, and why we've picked them, you can visit the [technologies section](../../../category/-technologies) to find out more.
+
+
+
+
 
 
 

--- a/docs/40_modules/93_base/01_Getting_Started/2-pre-requisite.md
+++ b/docs/40_modules/93_base/01_Getting_Started/2-pre-requisite.md
@@ -19,9 +19,7 @@ brew install git
 
 ## 2. Keycloak
 
-This frontend web template requires a functional Keycloak setup prior to deployment. Keycloak is an open-source identity and access management solution that provides authentication and authorization services. If not, please refer to our [quick start guide to Keycloak](../../../category/-quick-start)
-
-<!-- test -->
+This frontend web template requires a functional Keycloak setup prior to deployment. Keycloak is an open-source identity and access management solution that provides authentication and authorization services. For more information, please refer to our [quick start guide to Keycloak](../../../category/-quick-start)
 
 
 

--- a/docs/40_modules/93_base/02_project_structure/02_project_structure.md
+++ b/docs/40_modules/93_base/02_project_structure/02_project_structure.md
@@ -18,27 +18,49 @@ To maintain a structured and scalable application architecture, it is recommende
 
 ### Outline
 
-Here's a rough outline of the recommended structure:
+Here's a rough outline of the recommended structure as seen in our web-base repository:
 
 ```
 ├── lib
-│   ├── example_components
-│   │   ├── component1
-│   │   │   └── index.svelte
-│   │   └── component2
-│   │       └── index.svelte
+│   ├── _example
+│   │   └── components
+│   │       │── Headerbar
+│   │       │   └── index.svelte
+│   │       │
+│   │       └── Sidebar
+│   │           └── index.svelte
+│   ├── aoh
 │   ├── index.ts
 └── routes
     ├── (app)
-    │   └── aoh
-    │       └── example
-    │           ├── (private)
-    │           │   ├── +layout.server.ts
-    │           │   ├── +layout.svelte
-    │           │   ├── home
-    │           └── (public)
-    │               ├── +layout.server.ts
-    │               ├── +layout.svelte
-    │               └── login
+    │    ├── example
+    │    │    ├── (private)
+    │    │    │   ├── +layout.server.ts
+    │    │    │   ├── +layout.svelte
+    │    │    │   └── home
+    │    │    │       └── +page.svelte
+    │    │    │    ...
+    │    │    └── (public)
+    │    │        ├── +layout.server.ts
+    │    │        ├── +layout.svelte
+    │    │        └── login
+    │    │            └── +page.svelte
+    │    │── aoh
+             ...
     ...
 ```
+
+When creating a new component, you can create a new folder inside the `lib` folder. In the folder structure above, the `_example` folder is an example of how
+you should create a new component folder to build out the web-base. The `aoh` folder within `lib` consists of our `web core`, which contains the keycloak,
+logger and auth components.
+
+Similarly, when you want to create routes for your new components, you can create them following the file structure of the `_example` folder. As mentioned
+above, the `(public)` and `(private)` folders are where you will place your routes, depending on whether the routes require authentication or not.
+
+:::info
+
+The folder with parenthesis like `(public)` and `(private)` are called route groups in SvelteKit. Route groups help to make the configuration of
+authenticated vs non-authenticated routes easier to manage, among other things. For more information, you can visit SvelteKit's
+[documentation](https://kit.svelte.dev/docs/advanced-routing#advanced-layouts) or [tutorial](https://learn.svelte.dev/tutorial/route-groups).
+
+:::


### PR DESCRIPTION
Briefly mentioned the key technologies used like Svelte and SvelteKit, TypeScript, and TailwindCSS, and providing a link to our technologies section.

Not sure if we need to include others like playwright. (I see a playwright.config file but I'm assuming they are free to configure their own testing lib?)

Rephrased keycloak part in the web-base module section.

Updated folder structure diagram under Project Structure to reflect web-base's current folder structure. Also added explanations to ask users to follow ._example's folder structures when creating new components and routes using web-base.